### PR TITLE
Fix for #9: Value Conversion Error using provider::sops::string()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,8 @@ jobs:
           - "1.8.*"
           - "1.9.*"
           - "1.10.*"
+          - "1.11.*"
+          - "1.12.*"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobbs/terraform-provider-sops
 
-go 1.23.6
+go 1.24.3
 
 require (
 	github.com/getsops/sops/v3 v3.9.4

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,6 @@ package provider
 
 import (
 	"context"
-	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -13,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/lithammer/dedent"
 	"github.com/nobbs/terraform-provider-sops/internal/provider/utils"
 )
@@ -28,11 +26,6 @@ type SopsProvider struct {
 	// provider is built and ran locally, and "test" when running acceptance
 	// testing.
 	version string
-}
-
-// SopsProviderModel describes the provider data model.
-type SopsProviderModel struct {
-	Endpoint types.String `tfsdk:"endpoint"`
 }
 
 func (p *SopsProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -60,21 +53,7 @@ func (p *SopsProvider) Schema(ctx context.Context, req provider.SchemaRequest, r
 }
 
 func (p *SopsProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	var data SopsProviderModel
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Configuration values are now available.
-	// if data.Endpoint.IsNull() { /* ... */ }
-
-	// Example client configuration for data sources and resources
-	client := http.DefaultClient
-	resp.DataSourceData = client
-	resp.ResourceData = client
+	// no configuration needed
 }
 
 func (p *SopsProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.23"
+go = "1.24"
 goreleaser = "latest"
 
 [env]

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.22.7
+go 1.24.3
 
 require (
 	github.com/hashicorp/copywrite v0.19.0


### PR DESCRIPTION
Fixes #9 for OpenTofu by removing obsolete code fragments left over from the provider termplate.