### PR TITLE
ci(deps): fix dependabot auto merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+    
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge ${{ github.event.pull_request.number }}
         env:


### PR DESCRIPTION
This pull request updates the `.github/workflows/dependabot-auto-merge.yaml` file to include a step for checking out the repository code before enabling auto-merge for Dependabot pull requests.

Workflow updates:

* Added a `Checkout code` step using the `actions/checkout@v4` action to ensure the code is available in the workflow before executing subsequent steps.