### PR TITLE
ci: update Terraform acceptance test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,13 +61,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
+        # Test the latest five stable Terraform minor releases.
         terraform:
-          - "1.9.*"
-          - "1.10.*"
           - "1.11.*"
           - "1.12.*"
           - "1.13.*"
+          - "1.14.*"
+          - "1.15.*"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
## Summary

- test the latest five stable Terraform minor releases
- replace Terraform 1.9 and 1.10 with 1.14 and 1.15 in the acceptance-test matrix
- document the rolling five-minor support window in the workflow

All pinned GitHub Actions were audited against their upstream stable releases and are already current.

## Validation

- `actionlint .github/workflows/test.yml`
- `git diff --check`
- confirmed stable Terraform releases exist for every matrix line from 1.11 through 1.15