### PR TITLE
docs: warn about decrypted values in state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # SOPS Terraform Provider
 
-A Terraform provider for [sops](https://getsops.io/) providing functions to decrypt SOPS-encrypted files and strings. This provider is heavily inspired by [`carlpett/terraform-provider-sops`](https://github.com/carlpett/terraform-provider-sops) but does not rely on data sources and instead uses provider functions. This allows you to decrypt secrets without them necessarily being stored in the Terraform state as plain text.
+A Terraform provider for [sops](https://getsops.io/) providing functions to decrypt SOPS-encrypted files and strings. This provider is heavily inspired by [`carlpett/terraform-provider-sops`](https://github.com/carlpett/terraform-provider-sops) but does not rely on data sources and instead uses provider functions.
+
+> [!WARNING]
+> Provider functions do not store decrypted data independently. However, Terraform stores function results in state when they are assigned to outputs, resource attributes, or other state-backed values. Marking a value as `sensitive` only redacts it from normal output; it does not prevent the plaintext from being stored in state. Protect access to Terraform state accordingly.
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,10 @@ description: |-
   This provider is inspired by the
   carlpett/terraform-provider-sops https://registry.terraform.io/providers/carlpett/sops
   provider, but instead of using data sources, it implements its functionality as functions.
-  This approach provides more flexibility and ensures that decrypted data is not stored in the
-  state file.
+  Provider functions do not store decrypted data independently. However, Terraform stores function
+  results in state when they are assigned to outputs, resource attributes, or other state-backed
+  values. Marking a value as sensitive only redacts it from normal output; it does not prevent the
+  plaintext from being stored in state. Protect access to Terraform state accordingly.
   Moreover, if the decrypted data is in one of the supported formats (yaml, json, dotenv, ini), it will also be
   returned as a nested object in the data attribute. This allows for easier
   access to specific values within structured data.
@@ -20,8 +22,11 @@ The Sops provider offers functions to work with [sops](https://getsops.io/) encr
 This provider is inspired by the
 [carlpett/terraform-provider-sops](https://registry.terraform.io/providers/carlpett/sops)
 provider, but instead of using data sources, it implements its functionality as functions.
-This approach provides more flexibility and ensures that decrypted data is not stored in the
-state file.
+
+Provider functions do not store decrypted data independently. However, Terraform stores function
+results in state when they are assigned to outputs, resource attributes, or other state-backed
+values. Marking a value as sensitive only redacts it from normal output; it does not prevent the
+plaintext from being stored in state. Protect access to Terraform state accordingly.
 
 Moreover, if the decrypted data is in one of the supported formats (`yaml`, `json`, `dotenv`, `ini`), it will also be
 returned as a nested object in the `data` attribute. This allows for easier

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -41,8 +41,11 @@ func (p *SopsProvider) Schema(ctx context.Context, req provider.SchemaRequest, r
 			This provider is inspired by the
 			[carlpett/terraform-provider-sops](https://registry.terraform.io/providers/carlpett/sops)
 			provider, but instead of using data sources, it implements its functionality as functions.
-			This approach provides more flexibility and ensures that decrypted data is not stored in the
-			state file.
+
+			Provider functions do not store decrypted data independently. However, Terraform stores function
+			results in state when they are assigned to outputs, resource attributes, or other state-backed
+			values. Marking a value as sensitive only redacts it from normal output; it does not prevent the
+			plaintext from being stored in state. Protect access to Terraform state accordingly.
 
 			Moreover, if the decrypted data is in one of the supported formats (` + utils.Code("yaml") + `, ` +
 			utils.Code("json") + `, ` + utils.Code("dotenv") + `, ` + utils.Code("ini") + `), it will also be


### PR DESCRIPTION
## Summary

- remove the incorrect guarantee that provider functions keep decrypted values out of Terraform state
- explain when function results are persisted in state
- clarify that `sensitive` redacts normal output but does not prevent state storage
- regenerate the provider registry documentation

This addresses finding 1 from the repository review. The wording follows [Terraform's sensitive-data guidance](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).

## Validation

- `make generate`
- `go test -count=1 ./...`
- `gofmt -d internal/provider/provider.go`
- `git diff --check`