### PR TITLE
chore(deps): track tools module in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/tools"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- add the nested `/tools` Go module to Dependabot
- check copywrite, terraform-plugin-docs, and their dependency graph daily

This addresses finding 4 from the repository review.

## Validation

- `yamllint .github/dependabot.yml`
- parsed the configuration and verified the `/tools` `gomod` entry
- `git diff --check`

`yamllint` reports only the file's pre-existing missing document-start warning.