### PR TITLE
ci: replace deprecated GoReleaser archive format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,8 @@ builds:
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 
 archives:
-  - format: zip
+  - formats:
+      - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
## Summary

- replace the deprecated `archives.format` setting with `archives.formats`
- preserve ZIP archives and the existing archive naming scheme

This addresses finding 5 from the repository review.

## Validation

- `mise exec -- goreleaser check` with GoReleaser 2.9.0
- `mise x goreleaser@2.17.0 -- goreleaser check`
- `git diff --check`