### PR TITLE
fix: preserve Terraform number precision

### DIFF
--- a/internal/provider/utils/dynamictype.go
+++ b/internal/provider/utils/dynamictype.go
@@ -14,10 +14,12 @@ import (
 
 const nullStr = "null"
 
+const terraformNumberPrecision = 512
+
 // JSONToDynamicImplied is similar to FromJSON, while it is for typeless case.
 // In which case, the following type conversion rules are applied (Go -> TF):
 // - bool: bool
-// - float64: number
+// - json.Number: number
 // - string: string
 // - []interface{}: tuple
 // - map[string]interface{}: object
@@ -93,16 +95,21 @@ func attrValueFromJSONImplied(b []byte) (attr.Type, attr.Value, error) {
 	}
 
 	// Primitives
-	var v any
-	if err := json.Unmarshal(b, &v); err != nil {
+	v, err := decodeJSONPreservingNumbers(b)
+	if err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal %s: %w", string(b), err)
 	}
 
 	switch v := v.(type) {
 	case bool:
 		return types.BoolType, types.BoolValue(v), nil
-	case float64:
-		return types.NumberType, types.NumberValue(big.NewFloat(v)), nil
+	case json.Number:
+		number, _, err := big.ParseFloat(v.String(), 10, terraformNumberPrecision, big.ToNearestEven)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse number %s: %w", v, err)
+		}
+
+		return types.NumberType, types.NumberValue(number), nil
 	case string:
 		return types.StringType, types.StringValue(v), nil
 	case nil:

--- a/internal/provider/utils/dynamictype_test.go
+++ b/internal/provider/utils/dynamictype_test.go
@@ -1,0 +1,76 @@
+// Copyright Alexej Disterhoft <alexej@disterhoft.de> 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package utils
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestJSONToDynamicImpliedPreservesNumberPrecision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		number string
+	}{
+		{
+			name:   "integer beyond float64 exact range",
+			input:  `{"number":9007199254740993}`,
+			number: "9007199254740993",
+		},
+		{
+			name:   "decimal beyond float64 precision",
+			input:  `{"number":0.12345678901234567890123456789}`,
+			number: "0.12345678901234567890123456789",
+		},
+		{
+			name:   "number beyond float64 range",
+			input:  `{"number":1e1000}`,
+			number: "1e1000",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			jsonData, err := ReadJSON([]byte(test.input))
+			if err != nil {
+				t.Fatalf("ReadJSON() error = %v", err)
+			}
+
+			dynamicValue, err := JSONToDynamicImplied(jsonData)
+			if err != nil {
+				t.Fatalf("JSONToDynamicImplied() error = %v", err)
+			}
+
+			objectValue, ok := dynamicValue.UnderlyingValue().(types.Object)
+			if !ok {
+				t.Fatalf("JSONToDynamicImplied() underlying value type = %T, want types.Object", dynamicValue.UnderlyingValue())
+			}
+
+			numberValue, ok := objectValue.Attributes()["number"].(types.Number)
+			if !ok {
+				t.Fatalf("number attribute type = %T, want types.Number", objectValue.Attributes()["number"])
+			}
+
+			expected, _, err := big.ParseFloat(test.number, 10, 512, big.ToNearestEven)
+			if err != nil {
+				t.Fatalf("big.ParseFloat() error = %v", err)
+			}
+
+			if numberValue.ValueBigFloat().Cmp(expected) != 0 {
+				t.Errorf(
+					"number value = %s, want %s",
+					numberValue.ValueBigFloat().Text('g', -1),
+					expected.Text('g', -1),
+				)
+			}
+		})
+	}
+}

--- a/internal/provider/utils/dynamictype_test.go
+++ b/internal/provider/utils/dynamictype_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// terraformProtocolNumberPrecision intentionally remains independent of the
+// production constant so this test detects drift from Terraform's precision.
+const terraformProtocolNumberPrecision = 512
+
 func TestJSONToDynamicImpliedPreservesNumberPrecision(t *testing.T) {
 	t.Parallel()
 
@@ -59,7 +63,12 @@ func TestJSONToDynamicImpliedPreservesNumberPrecision(t *testing.T) {
 				t.Fatalf("number attribute type = %T, want types.Number", objectValue.Attributes()["number"])
 			}
 
-			expected, _, err := big.ParseFloat(test.number, 10, 512, big.ToNearestEven)
+			expected, _, err := big.ParseFloat(
+				test.number,
+				10,
+				terraformProtocolNumberPrecision,
+				big.ToNearestEven,
+			)
 			if err != nil {
 				t.Fatalf("big.ParseFloat() error = %v", err)
 			}

--- a/internal/provider/utils/formats.go
+++ b/internal/provider/utils/formats.go
@@ -14,18 +14,16 @@ import (
 )
 
 func decodeJSONPreservingNumbers(data []byte) (any, error) {
-	if !json.Valid(data) {
-		var value any
-
-		return nil, json.Unmarshal(data, &value)
-	}
-
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 
 	var value any
 	if err := decoder.Decode(&value); err != nil {
-		return nil, err
+		return nil, json.Unmarshal(data, &value)
+	}
+
+	if len(bytes.TrimSpace(data[decoder.InputOffset():])) != 0 {
+		return nil, json.Unmarshal(data, &value)
 	}
 
 	return value, nil

--- a/internal/provider/utils/formats.go
+++ b/internal/provider/utils/formats.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 
@@ -11,6 +12,24 @@ import (
 	"github.com/wlevene/ini"
 	"gopkg.in/yaml.v3"
 )
+
+func decodeJSONPreservingNumbers(data []byte) (any, error) {
+	if !json.Valid(data) {
+		var value any
+
+		return nil, json.Unmarshal(data, &value)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+
+	return value, nil
+}
 
 func IsValidFormat(format string) bool {
 	return format == "yaml" || format == "json" || format == "dotenv" || format == "ini" || format == "binary"
@@ -57,8 +76,7 @@ func ReadYAML(data []byte) ([]byte, error) {
 }
 
 func ReadJSON(data []byte) ([]byte, error) {
-	var v any
-	err := json.Unmarshal(data, &v)
+	v, err := decodeJSONPreservingNumbers(data)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/utils/formats_test.go
+++ b/internal/provider/utils/formats_test.go
@@ -1,0 +1,83 @@
+// Copyright Alexej Disterhoft <alexej@disterhoft.de> 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecodeJSONPreservingNumbersAllowsTrailingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	value, err := decodeJSONPreservingNumbers([]byte("{\"number\":9007199254740993}\n\t "))
+	if err != nil {
+		t.Fatalf("decodeJSONPreservingNumbers() error = %v", err)
+	}
+
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("decodeJSONPreservingNumbers() type = %T, want map[string]any", value)
+	}
+
+	number, ok := object["number"].(json.Number)
+	if !ok {
+		t.Fatalf("number type = %T, want json.Number", object["number"])
+	}
+
+	if got, want := number.String(), "9007199254740993"; got != want {
+		t.Errorf("number = %q, want %q", got, want)
+	}
+}
+
+func TestDecodeJSONPreservingNumbersRejectsTrailingData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "second object",
+			input: `{} {}`,
+		},
+		{
+			name:  "invalid token",
+			input: `{} invalid`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, gotErr := decodeJSONPreservingNumbers([]byte(test.input))
+
+			var value any
+			wantErr := json.Unmarshal([]byte(test.input), &value)
+			if gotErr == nil {
+				t.Fatal("decodeJSONPreservingNumbers() error = nil, want error")
+			}
+			if gotErr.Error() != wantErr.Error() {
+				t.Errorf(
+					"decodeJSONPreservingNumbers() error = %q, want %q",
+					gotErr,
+					wantErr,
+				)
+			}
+		})
+	}
+}
+
+func BenchmarkDecodeJSONPreservingNumbers(b *testing.B) {
+	data := []byte(
+		`{"number":9007199254740993,"decimal":0.12345678901234567890123456789,"values":[1,2,3,4,5]}`,
+	)
+
+	for b.Loop() {
+		if _, err := decodeJSONPreservingNumbers(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- preserve JSON number text instead of decoding through `float64`
- parse dynamic Terraform numbers with the same 512-bit precision used by `terraform-plugin-go`
- add regression coverage for integers and decimals beyond `float64` precision and numbers beyond its range

This addresses finding 2 from the repository review.

## Test-first reproduction

Before the implementation change, the regression test failed with:

```text
number value = 9.007199254740992e+15, want 9.007199254740993e+15
ReadJSON() error = json: cannot unmarshal number 1e1000 into Go value of type float64
```

## Validation

- `go test -count=1 -run TestJSONToDynamicImpliedPreservesNumberPrecision -v ./internal/provider/utils`
- `go test -race -count=1 -timeout=10m ./...`
- `go vet ./...`
- `go build ./...`
- `make generate`
- `git diff --check`