### PR TITLE
chore(deps): update Go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nobbs/terraform-provider-sops
 
-go 1.25.12
+go 1.26.0
+
+toolchain go1.26.5
 
 require (
 	github.com/getsops/sops/v3 v3.13.3

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.25"
+go = "1.26.5"
 goreleaser = "latest"
 
 [env]

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,8 @@
 module tools
 
-go 1.25.12
+go 1.26.0
+
+toolchain go1.26.5
 
 require (
 	github.com/hashicorp/copywrite v0.25.3


### PR DESCRIPTION
## Summary

- set the root and tools modules to `go 1.26.0`
- pin the suggested toolchain to `go1.26.5`
- align the mise development runtime with Go 1.26.5

## Validation

- `go mod verify`
- `go -C tools mod verify`
- `go build ./...`
- `go vet ./...`
- `go test -count=1 -timeout=10m ./...`
- `go test -race -count=1 ./internal/provider/utils`
- `make generate`