### PR TITLE
ci: support immutable GitHub releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,6 +58,7 @@ signs:
       - "${artifact}"
 release:
   mode: keep-existing
+  use_existing_draft: true
 
   extra_files:
     - glob: "terraform-registry-manifest.json"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://github.com/googleapis/release-please/raw/refs/heads/main/schemas/config.json",
+  "draft": true,
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "release-type": "go"


### PR DESCRIPTION
## Summary

- have Release Please create draft releases and force tag creation
- configure GoReleaser to reuse the existing draft
- preserve Release Please release notes while allowing GoReleaser to upload and sign artifacts before publication

## Context

The `v0.3.2` release workflow failed because Release Please published the release before GoReleaser uploaded its artifacts. With immutable releases enabled, every upload was rejected with HTTP 422.

Failed run: https://github.com/nobbs/terraform-provider-sops/actions/runs/29997704416/job/89175214454

The existing immutable `v0.3.2` release cannot be amended; corrected artifacts will be produced by the next release.

## Validation

- `jq empty release-please-config.json`
- `mise exec -- goreleaser check`
- `mise exec -- goreleaser release --snapshot --clean --skip=sign`